### PR TITLE
Support Spring Pre-Release Package Downloads

### DIFF
--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # install nodeos locally 
 

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -6,13 +6,11 @@ set -eo pipefail
 LEAP_VERSION="${1}"
 OS="ubuntu22.04"
 if [ "${LEAP_VERSION:0:1}" == "4" ]; then
-    v4_DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
-    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v4_DEB_FILE}"
-    DEB_FILE=${v4_DEB_FILE}
+    DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 else
-    v5_DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
-    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v5_DEB_FILE}"
-    DEB_FILE=${v5_DEB_FILE}
+    DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 fi
 
 ## root setup ##

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -16,8 +16,7 @@ fi
 
 ## root setup ##
 # clean out un-needed files
-for not_needed_deb_file in "${HOME:?}"/leap_*.deb
-do
+for not_needed_deb_file in "${HOME:?}"/leap_*.deb; do
     if [ "${not_needed_deb_file}" != "${HOME:?}"/"${DEB_FILE}" ]; then
         echo "Removing not needed deb ${not_needed_deb_file}"
         rm -rf ${not_needed_deb_file}

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -5,32 +5,32 @@ set -eo pipefail
 
 LEAP_VERSION="${1}"
 OS="ubuntu22.04"
-v4_DEB_FILE="leap_""${LEAP_VERSION}"-"${OS}""_amd64.deb"
-v5_DEB_FILE="leap_""${LEAP_VERSION}""_amd64.deb"
+v4_DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
+v5_DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
 if [ "${LEAP_VERSION:0:1}" == "4" ]; then
-    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v4_DEB_FILE}"
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v4_DEB_FILE}"
     DEB_FILE=${v4_DEB_FILE}
 else
-    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v5_DEB_FILE}"
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v5_DEB_FILE}"
     DEB_FILE=${v5_DEB_FILE}
 fi
 
 ## root setup ##
 # clean out un-needed files
 for not_needed_deb_file in "${HOME:?}"/leap_*.deb; do
-    if [ "${not_needed_deb_file}" != "${HOME:?}"/"${DEB_FILE}" ]; then
+    if [ "${not_needed_deb_file}" != "${HOME:?}/${DEB_FILE}" ]; then
         echo "Removing not needed deb ${not_needed_deb_file}"
         rm -rf "${not_needed_deb_file}"
     fi
 done
 
 # download file if needed
-if [ ! -f "${HOME:?}"/"${DEB_FILE}" ]; then
+if [ ! -f "${HOME:?}/${DEB_FILE}" ]; then
     wget --directory-prefix="${HOME}" "${DEB_URL}" 2> /dev/null
 fi
 
 # install nodeos locally
 echo "Installing nodeos ${LEAP_VERSION} locally"
-[ -d "${HOME:?}"/nodeos ] && rm -rf "${HOME:?}"/nodeos
-mkdir "${HOME:?}"/nodeos
-dpkg -x "${HOME:?}"/"${DEB_FILE}" "${HOME:?}"/nodeos
+[ -d "${HOME:?}/nodeos" ] && rm -rf "${HOME:?}/nodeos"
+mkdir "${HOME:?}/nodeos"
+dpkg -x "${HOME:?}/${DEB_FILE}" "${HOME:?}/nodeos"

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -22,7 +22,7 @@ if [[ "${DRY_RUN}" == 'true' ]]; then
     echo "OS='${OS}'"
     echo "DEB_FILE='${DEB_FILE}'"
     echo "DEB_URL='${DEB_URL}'"
-    echo 'Exiting...'
+    echo "Exiting... - ${BASH_SOURCE[0]}"
     exit 0
 fi
 
@@ -45,3 +45,5 @@ echo "Installing nodeos ${LEAP_VERSION} locally"
 [ -d "${HOME:?}/nodeos" ] && rm -rf "${HOME:?}/nodeos"
 mkdir "${HOME:?}/nodeos"
 dpkg -x "${HOME:?}/${DEB_FILE}" "${HOME:?}/nodeos"
+
+echo "Done. - ${BASH_SOURCE[0]}"

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -16,6 +16,7 @@ else  # spring
 fi
 
 ## dry-run
+[[ "$(echo "$2" | grep -icP '^DRY(-_)>RUN$')" == '1' ]] && export DRY_RUN='true'
 if [[ "${DRY_RUN}" == 'true' ]]; then
     prinf "\e[1;33mWARNING: DRY-RUN is set!\e[0m\n"
     echo "LEAP_VERSION='${LEAP_VERSION}'"

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# install nodeos locally 
-
+# install nodeos locally
 LEAP_VERSION="${1}"
 OS="ubuntu22.04"
 if [ "${LEAP_VERSION:0:1}" == "4" ]; then

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -7,26 +7,26 @@ OS="ubuntu22.04"
 v4_DEB_FILE="leap_""${LEAP_VERSION}"-"${OS}""_amd64.deb"
 v5_DEB_FILE="leap_""${LEAP_VERSION}""_amd64.deb"
 if [ ${LEAP_VERSION:0:1} == "4" ]; then
-  DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v4_DEB_FILE}"
-  DEB_FILE=${v4_DEB_FILE}
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v4_DEB_FILE}"
+    DEB_FILE=${v4_DEB_FILE}
 else
-  DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v5_DEB_FILE}"
-  DEB_FILE=${v5_DEB_FILE}
+    DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v5_DEB_FILE}"
+    DEB_FILE=${v5_DEB_FILE}
 fi
 
 ## root setup ##
 # clean out un-needed files
 for not_needed_deb_file in "${HOME:?}"/leap_*.deb
 do
-  if [ "${not_needed_deb_file}" != "${HOME:?}"/"${DEB_FILE}" ]; then
-    echo "Removing not needed deb ${not_needed_deb_file}"
-    rm -rf ${not_needed_deb_file}
-  fi
+    if [ "${not_needed_deb_file}" != "${HOME:?}"/"${DEB_FILE}" ]; then
+        echo "Removing not needed deb ${not_needed_deb_file}"
+        rm -rf ${not_needed_deb_file}
+    fi
 done
 
 # download file if needed
 if [ ! -f "${HOME:?}"/"${DEB_FILE}" ]; then
-  wget --directory-prefix=${HOME} "${DEB_URL}" 2> /dev/null
+    wget --directory-prefix=${HOME} "${DEB_URL}" 2> /dev/null
 fi
 
 # install nodeos locally

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # install nodeos locally 
 

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 # install nodeos locally
-LEAP_VERSION="${1}"
+LEAP_VERSION="${1#v}"
 OS="ubuntu22.04"
 if [[ "${LEAP_VERSION:0:1}" == '4' ]]; then
     DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -6,7 +6,7 @@ LEAP_VERSION="${1}"
 OS="ubuntu22.04"
 v4_DEB_FILE="leap_""${LEAP_VERSION}"-"${OS}""_amd64.deb"
 v5_DEB_FILE="leap_""${LEAP_VERSION}""_amd64.deb"
-if [ ${LEAP_VERSION:0:1} == "4" ]; then
+if [ "${LEAP_VERSION:0:1}" == "4" ]; then
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v""${LEAP_VERSION}"/"${v4_DEB_FILE}"
     DEB_FILE=${v4_DEB_FILE}
 else
@@ -19,13 +19,13 @@ fi
 for not_needed_deb_file in "${HOME:?}"/leap_*.deb; do
     if [ "${not_needed_deb_file}" != "${HOME:?}"/"${DEB_FILE}" ]; then
         echo "Removing not needed deb ${not_needed_deb_file}"
-        rm -rf ${not_needed_deb_file}
+        rm -rf "${not_needed_deb_file}"
     fi
 done
 
 # download file if needed
 if [ ! -f "${HOME:?}"/"${DEB_FILE}" ]; then
-    wget --directory-prefix=${HOME} "${DEB_URL}" 2> /dev/null
+    wget --directory-prefix="${HOME}" "${DEB_URL}" 2> /dev/null
 fi
 
 # install nodeos locally

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -7,9 +7,12 @@ OS="ubuntu22.04"
 if [[ "${LEAP_VERSION:0:1}" == '4' ]]; then
     DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
-else
+elif [[ "${LEAP_VERSION:0:1}" == '5' ]]; then
     DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
+else  # spring
+    DEB_FILE="antelope-spring_${LEAP_VERSION}-${OS}_amd64.deb"
+    DEB_URL="https://github.com/AntelopeIO/spring/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 fi
 
 ## root setup ##

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -15,6 +15,17 @@ else  # spring
     DEB_URL="https://github.com/AntelopeIO/spring/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 fi
 
+## dry-run
+if [[ "${DRY_RUN}" == 'true' ]]; then
+    prinf "\e[1;33mWARNING: DRY-RUN is set!\e[0m\n"
+    echo "LEAP_VERSION='${LEAP_VERSION}'"
+    echo "OS='${OS}'"
+    echo "DEB_FILE='${DEB_FILE}'"
+    echo "DEB_URL='${DEB_URL}'"
+    echo 'Exiting...'
+    exit 0
+fi
+
 ## root setup ##
 # clean out un-needed files
 for not_needed_deb_file in "${HOME:?}"/leap_*.deb; do

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 # install nodeos locally
 LEAP_VERSION="${1}"
 OS="ubuntu22.04"
-if [ "${LEAP_VERSION:0:1}" == "4" ]; then
+if [[ "${LEAP_VERSION:0:1}" == '4' ]]; then
     DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 else

--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -5,12 +5,12 @@ set -eo pipefail
 
 LEAP_VERSION="${1}"
 OS="ubuntu22.04"
-v4_DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
-v5_DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
 if [ "${LEAP_VERSION:0:1}" == "4" ]; then
+    v4_DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v4_DEB_FILE}"
     DEB_FILE=${v4_DEB_FILE}
 else
+    v5_DEB_FILE="leap_${LEAP_VERSION}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${v5_DEB_FILE}"
     DEB_FILE=${v5_DEB_FILE}
 fi


### PR DESCRIPTION
From engineering [issue 100](https://github.com/eosnetworkfoundation/engineering/issues/100), this pull request adds support for running "chicken dance" full-chain replays against Spring pre-release binaries.

Previously, the script looked for a `LEAP_VERSION` string beginning with `4`, then downloaded a [Leap](https://github.com/AntelopeIO/leap) v4.x package using that nomenclature. Anything else was assumed to be Leap v5.x.

The new behavior uses the same pattern to look for a `4` or a `5`, which causes the previous behavior. Anything else is assumed to be a reference to [Spring](https://github.com/AntelopeIO/spring), in which case it will pull from that repo.

I have also added a dry-run function that prints the inputs and the constructed URI if `DRY_RUN` is set to `true`, or if the second argument matches `^DRY(-_)?RUN$` (case-insensitive), for debugging.

The script now also permits the leaving `v` in version strings, such as `v0.0.0` instead of `0.0.0`, as this is how I would expect a system to expect version strings.

Finally, this pull request includes changes to this `install-nodeos.sh` file to comply with [bashate](https://github.com/openstack/bashate) (essentially pep8, but for BASH)...
```bash
bashate -i E006 install-nodeos.sh
```
...and [ShellCheck](https://github.com/koalaman/shellcheck).
```bash
shellcheck -x -f gcc install-nodeos.sh
```