### PR TITLE
Support Testing Against Local Builds

### DIFF
--- a/replay-client/install-nodeos.sh
+++ b/replay-client/install-nodeos.sh
@@ -4,7 +4,10 @@ set -eo pipefail
 # install nodeos locally
 LEAP_VERSION="${1#v}"
 OS="ubuntu22.04"
-if [[ "${LEAP_VERSION:0:1}" == '4' ]]; then
+if [[ "$(echo "$LEAP_VERSION" | grep ic 'local')" == '1' ]]; then
+    DEB_FILE="antelope-spring_${LEAP_VERSION}-${OS}_amd64.deb"
+    DEB_URL="https://replay.enf.land/packages/${DEB_FILE}"
+elif [[ "${LEAP_VERSION:0:1}" == '4' ]]; then
     DEB_FILE="leap_${LEAP_VERSION}-${OS}_amd64.deb"
     DEB_URL="https://github.com/AntelopeIO/leap/releases/download/v${LEAP_VERSION}/${DEB_FILE}"
 elif [[ "${LEAP_VERSION:0:1}" == '5' ]]; then


### PR DESCRIPTION
From engineering [issue 100](https://github.com/eosnetworkfoundation/engineering/issues/100), this pull request introduces a mechanism to run replay testing against local builds of `nodeos`.

Previously, the operator provided a tag against which the replay should be performed.
```
v0.0.0-rc0
```
Based on that tag, the replay system obtained a `nodeos` binary from a specific GitHub endpoint.

However, for Spring, a customer wishes to test a custom build performed on their local machine. The customer has published that build at an endpoint. Here, the system looks for tags containing `local`.
```
v0.0.0-local
```
When such a tag is found, the tag is downloaded from an endpoint with the corresponding version.
```
https://replay.enf.land/packages/antelope-spring_0.0.0-local-ubuntu22.04_amd64.deb
```